### PR TITLE
Fix XStream Security Vulnerability in XML Deserialization

### DIFF
--- a/tis-plugin/src/main/java/com/qlangtech/tis/extension/impl/XmlFile.java
+++ b/tis-plugin/src/main/java/com/qlangtech/tis/extension/impl/XmlFile.java
@@ -78,7 +78,35 @@ public final class XmlFile {
         return file;
     }
 
+        /**
+     * Returns a security-hardened XStream instance
+     */
     public XStream getXStream() {
+        // Apply security hardening to the existing XStream instance
+        // This only needs to happen once
+        if (!xsSecurityInitialized) {
+            synchronized(this) {
+                if (!xsSecurityInitialized) {
+                    // Apply security configurations to the existing xs instance
+                    
+                    // Set up allowlist for permitted classes
+                    xs.allowTypesByWildcard(new String[] {
+                        "com.qlangtech.tis.**"
+                        // Add other necessary packages your application needs
+                    });
+                    
+                    // Block commonly exploited classes
+                    xs.denyTypes(new Class[] {
+                        java.lang.System.class,
+                        java.lang.ProcessBuilder.class,
+                        java.lang.Runtime.class
+                    });
+                    
+                    xsSecurityInitialized = true;
+                }
+            }
+        }
+        
         return xs;
     }
 


### PR DESCRIPTION
## Description
This PR addresses a critical security vulnerability (CVE-2021-21341 and similar) in our XStream usage that could allow remote code execution through XML deserialization attacks. The current implementation lacked proper security restrictions on the XStream instance, allowing deserialization of arbitrary classes.

This vulnerability was also found in t-oster/VisiCut@3d6b930, corresponding to CVE-2021-39141 and fixed in this git commit.

**References:**
1. https://nvd.nist.gov/vuln/detail/cve-2021-39141
2. t-oster/VisiCut@3d6b930